### PR TITLE
Allow Python 3.13

### DIFF
--- a/.github/workflows/python-testing-linux.yml
+++ b/.github/workflows/python-testing-linux.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9","3.10","3.11","3.12"]
+        python-version: ["3.9","3.10","3.11","3.12","3.13"]
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/python-testing-macos.yml
+++ b/.github/workflows/python-testing-macos.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macos-latest"]
-        python-version: ["3.9", "3.10","3.11","3.12"]
+        python-version: ["3.9", "3.10","3.11","3.12","3.13"]
     steps:
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = ">= 3.9, < 3.13"
+requires-python = ">= 3.9, < 3.14"
 
 dependencies = [
     'pytest',


### PR DESCRIPTION
After using it locally, I can put my hand on the fire that there are no issues with Python 3.13.

This also aligns the requires-python with the versions used in xradio and other viper repos.