### PR TITLE
Support loading subsets of the binary components present in the BDFs

### DIFF
--- a/src/pyasdm/bdf/BDFReader.py
+++ b/src/pyasdm/bdf/BDFReader.py
@@ -738,6 +738,7 @@ class BDFReader:
 
         except Exception as exc:
             import traceback
+
             traceback.print_exc()
             raise BDFReaderException(
                 "Unexpected exception while parsing the main BDF header: '"
@@ -805,12 +806,12 @@ class BDFReader:
         ).value
         projectPathParts = projectPath.split("/")
         # drop the last part if projectPath ends in a "/"
-        if projectPath.endswith('/'):
+        if projectPath.endswith("/"):
             projectPathParts = projectPathParts[:-1]
         numPathParts = len(projectPathParts)
         if self.isCorrelation():
             # correlator data should have 4 of 5 parts here
-            if ((numPathParts < 4) or (numPathParts > 5)):
+            if (numPathParts < 4) or (numPathParts > 5):
                 raise BDFReaderException(
                     "Invalid string for projectPath, expectes 4 or 5 parts '"
                     + projectPath
@@ -818,13 +819,13 @@ class BDFReader:
                 )
         else:
             # TP data should have 3 or 4 parts here
-            if ((numPathParts < 3) or (numPathParts > 4)):
+            if (numPathParts < 3) or (numPathParts > 4):
                 raise BDFReaderException(
                     "Invalid string for projectPath, expects 3 or 4 parts '"
                     + projectPath
                     + "'"
-                    )
-            
+                )
+
         execBlockNum = int(projectPathParts[0])
         scanNum = int(projectPathParts[1])
         subscanNum = int(projectPathParts[2])
@@ -899,52 +900,28 @@ class BDFReader:
         # if it's aborted, this can probably be skipped, but it should also be harmless to not skip it just in case there's more there to be skipped over
         # no aborted scans available yet to test this on
 
-        actualTimesDesc = {}
-        actualTimesDesc["present"] = False
-        actualTimesDesc["startsAt"] = -1
-        actualTimesDesc["arr"] = None
-        actualTimesDesc["type"] = "INT64_TYPE"
-        actualTimesDesc["np_type"] = np.dtype(np.int64)
-
-        actualDurationsDesc = {}
-        actualDurationsDesc["present"] = False
-        actualDurationsDesc["startsAt"] = -1
-        actualDurationsDesc["arr"] = None
-        actualDurationsDesc["type"] = "INT64_TYPE"
-        actualDurationsDesc["np_type"] = np.dtype(np.int64)
-
-        crossDataDesc = {}
-        crossDataDesc["present"] = False
-        crossDataDesc["startsAt"] = -1
-        crossDataDesc["arr"] = None
-        crossDataDesc["type"] = None
-        crossDataDesc["np_type"] = None
+        binaryComponents = {
+            "actualTimes": {"type": "INT64_TYPE", "np_type": np.dtype(np.int64)},
+            "actualDurations": {"type": "INT64_TYPE", "np_type": np.dtype(np.int64)},
+            "crossData": {"type": None, "np_type": None},
+            "autoData": {"type": "FLOAT32_TYPE", "np_type": np.dtype(np.float32)},
+            "flags": {"type": "INT32_TYPE", "np_type": np.dtype(np.int32)},
+            "zeroLags": {"type": "FLOAT32_TYPE", "np_type": np.dtype(np.float32)},
+        }
+        binaryComponentsDesc = {}
+        for component in binaryComponents:
+            binaryComponentsDesc[component] = {
+                "present": False,
+                "startsAt": -1,
+                "arr": None,
+                "type": binaryComponents[component]["type"],
+                "np_type": binaryComponents[component]["np_type"],
+            }
 
         # the actual crossDataDesc varies among these types
         npInt16 = np.dtype(np.int16)
         npInt32 = np.dtype(np.int32)
         npFloat32 = np.dtype(np.float32)
-
-        autoDataDesc = {}
-        autoDataDesc["present"] = False
-        autoDataDesc["startsAt"] = -1
-        autoDataDesc["arr"] = None
-        autoDataDesc["type"] = "FLOAT32_TYPE"
-        autoDataDesc["np_type"] = np.dtype(np.float32)
-
-        flagsDesc = {}
-        flagsDesc["present"] = False
-        flagsDesc["startsAt"] = -1
-        flagsDesc["arr"] = None
-        flagsDesc["type"] = "INT32_TYPE"
-        flagsDesc["np_type"] = np.dtype(np.int32)
-
-        zeroLagsDesc = {}
-        zeroLagsDesc["present"] = False
-        zeroLagsDesc["startsAt"] = -1
-        zeroLagsDesc["arr"] = None
-        zeroLagsDesc["type"] = "FLOAT32_TYPE"
-        zeroLagsDesc["np_type"] = np.dtype(np.float32)
 
         # adjust the numpy data types when the byte order is not native
         if not self._bdfHeaderData.getByteOrder().isNative():
@@ -1018,7 +995,7 @@ class BDFReader:
                         % elements[0].nodeName
                     )
 
-                crossDataDesc["type"] = crossDataType
+                binaryComponentsDesc["crossData"]["type"] = crossDataType
 
             self._skipUntilEmptyLine(10)
 
@@ -1032,13 +1009,13 @@ class BDFReader:
             elif binaryPartName == b"crossData":
                 if crossDataType == "INT16_TYPE":
                     numberOfBytesPerValue = 2
-                    crossDataDesc["np_type"] = npInt16
+                    binaryComponentsDesc["crossData"]["np_type"] = npInt16
                 elif crossDataType == "INT32_TYPE":
                     numberOfBytesPerValue = 4
-                    crossDataDesc["np_type"] = npInt32
+                    binaryComponentsDesc["crossData"]["np_type"] = npInt32
                 elif crossDataType == "FLOAT32_TYPE":
                     numberOfBytesPerValue = 4
-                    crossDataDesc["np_type"] = npFloat32
+                    binaryComponentsDesc["crossData"]["np_type"] = npFloat32
             elif binaryPartName == b"flags":
                 numberOfBytesPerValue = 4
             elif binaryPartName == b"zeroLags":
@@ -1052,86 +1029,26 @@ class BDFReader:
                     + "'."
                 )
 
-            numberOfElementsToRead = self._binaryPartSize[
-                binaryPartName.decode("utf-8")
-            ]
+            componentName = binaryPartName.decode("utf-8")
+            numberOfElementsToRead = self._binaryPartSize[componentName]
             numberOfBytesToRead = numberOfBytesPerValue * numberOfElementsToRead
 
             # with restructuring, this can also be cleaner - TBD
             # actual number of bytes read
             nReadBytes = None
             actualReadSkipped = False
-            if binaryPartName == b"zeroLags":
-                zeroLagsDesc["present"] = True
-                zeroLagsDesc["startsAt"] = self.position()
-                dt = zeroLagsDesc["np_type"]
-                if not loadOnlyComponents or "zeroLags" in loadOnlyComponents:
-                    zeroLagsDesc["arr"] = np.fromfile(
+            if componentName in binaryComponents:
+                componentDesc = binaryComponentsDesc[componentName]
+                componentDesc["present"] = True
+                componentDesc["startsAt"] = self.position()
+                dt = componentDesc["np_type"]
+                if not loadOnlyComponents or componentName in loadOnlyComponents:
+                    componentDesc["arr"] = np.fromfile(
                         self._f, dtype=dt, count=numberOfElementsToRead
                     )
-                    nReadBytes = zeroLagsDesc["arr"].size * numberOfBytesPerValue
+                    nReadBytes = componentDesc["arr"].size * numberOfBytesPerValue
                 else:
-                    zeroLagsDesc["arr"] = None
-                    actualReadSkipped = True
-            elif binaryPartName == b"actualTimes":
-                actualTimesDesc["present"] = True
-                actualTimesDesc["startsAt"] = self.position()
-                dt = actualTimesDesc["np_type"]
-                if not loadOnlyComponents or "actualTimes" in loadOnlyComponents:
-                    actualTimesDesc["arr"] = np.fromfile(
-                        self._f, dtype=dt, count=numberOfElementsToRead
-                    )
-                    nReadBytes = len(actualTimesDesc["arr"]) * numberOfBytesPerValue
-                else:
-                    actualTimesDesc["arr"] = None
-                    actualReadSkipped = True
-            elif binaryPartName == b"actualDurations":
-                actualDurationsDesc["present"] = True
-                actualDurationsDesc["startsAt"] = self.position()
-                dt = actualDurationsDesc["np_type"]
-                if not loadOnlyComponents or "actualDurations" in loadOnlyComponents:
-                    actualDurationsDesc["arr"] = np.fromfile(
-                        self._f, dtype=dt, count=numberOfElementsToRead
-                    )
-                    nReadBytes = len(actualDurationsDesc["arr"]) * numberOfBytesPerValue
-                else:
-                    actualDurationsDesc["arr"] = None
-                    actualReadSkipped = True
-            elif binaryPartName == b"crossData":
-                crossDataDesc["present"] = True
-                crossDataDesc["startsAt"] = self.position()
-                dt = crossDataDesc["np_type"]
-                if not loadOnlyComponents or "crossData" in loadOnlyComponents:
-                    crossDataDesc["arr"] = np.fromfile(
-                        self._f, dtype=dt, count=numberOfElementsToRead
-                    )
-                    nReadBytes = len(crossDataDesc["arr"]) * numberOfBytesPerValue
-                else:
-                    crossDataDesc["arr"] = None
-                    actualReadSkipped = True
-            elif binaryPartName == b"autoData":
-                autoDataDesc["present"] = True
-                autoDataDesc["startsAt"] = self.position()
-                dt = autoDataDesc["np_type"]
-                if not loadOnlyComponents or "autoData" in loadOnlyComponents:
-                    autoDataDesc["arr"] = np.fromfile(
-                        self._f, dtype=dt, count=numberOfElementsToRead
-                    )
-                    nReadBytes = len(autoDataDesc["arr"]) * numberOfBytesPerValue
-                else:
-                    autoDataDesc["arr"] = None
-                    actualReadSkipped = True
-            elif binaryPartName == b"flags":
-                flagsDesc["present"] = True
-                flagsDesc["startsAt"] = self.position()
-                dt = flagsDesc["np_type"]
-                if not loadOnlyComponents or "flags" in loadOnlyComponents:
-                    flagsDesc["arr"] = np.fromfile(
-                        self._f, dtype=dt, count=numberOfElementsToRead
-                    )
-                    nReadBytes = len(flagsDesc["arr"]) * numberOfBytesPerValue
-                else:
-                    flagsDesc["arr"] = None
+                    componentDesc["arr"] = None
                     actualReadSkipped = True
             else:
                 # should never reach here ! but just in case
@@ -1183,12 +1100,12 @@ class BDFReader:
             "aborted": aborted,
             "stopTime": stopTime,
             "abortReason": abortReason,
-            "actualTimes": actualTimesDesc,
-            "actualDurations": actualDurationsDesc,
-            "crossData": crossDataDesc,
-            "autoData": autoDataDesc,
-            "flags": flagsDesc,
-            "zeroLags": zeroLagsDesc,
+            "actualTimes": binaryComponentsDesc["actualTimes"],
+            "actualDurations": binaryComponentsDesc["actualDurations"],
+            "crossData": binaryComponentsDesc["crossData"],
+            "autoData": binaryComponentsDesc["autoData"],
+            "flags": binaryComponentsDesc["flags"],
+            "zeroLags": binaryComponentsDesc["zeroLags"],
         }
 
     def _setPosition(self, newpos):


### PR DESCRIPTION
Resolves #5.

Opening this PR for review/discussion. This implements the idea of #5, where one can request a subset of the binary components to be loaded. 
This implementation adds a `loadOnlyComponents: set` parameter to `getSubset()` where one can specify the subset of binary components. This is the simplest interface I could come up with and it made sense to me, but there might be other alternatives.

This is working well with the branch of https://github.com/casangi/xradio/issues/454, and already shows that the open time is reduced by a factor of many (sometimes >10s) when for example only interested in the `actualTimes` and `actualDurations`, or the `flags`. 

The feature is implemented in the first commit. The second commit reorganizes a bit `_requireSDMDataSubsetMIMEPart()` to reduce duplication of code (using a dict of descriptions for the individual binary components).