### PR TITLE
Fixes issue #10 and #11

### DIFF
--- a/src/pyasdm/FeedTable.py
+++ b/src/pyasdm/FeedTable.py
@@ -558,7 +558,7 @@ class FeedTable:
         # make sure there are enough rows in contextRows to hold insertionId
         # probably this just adds one list to contextRows
         while len(contextRows) <= insertionId:
-            contetRows.append([])
+            contextRows.append([])
 
         # and insert this row into the list at insertionId so that list remains ordered in time
         result = self.insertByStartTime(x, contextRows[insertionId])

--- a/src/pyasdm/HistoryTable.py
+++ b/src/pyasdm/HistoryTable.py
@@ -365,7 +365,7 @@ class HistoryTable:
             # Create and initialize an entry in the context dict for this combination....
             self._context[keystr] = []
 
-        result = insertByTime(x, self._context[keystr])
+        result = self.insertByTime(x, self._context[keystr])
         return result
 
     def newRow(

--- a/src/pyasdm/MainTable.py
+++ b/src/pyasdm/MainTable.py
@@ -378,7 +378,7 @@ class MainTable:
             # Create and initialize an entry in the context dict for this combination....
             self._context[keystr] = []
 
-        result = insertByTime(x, self._context[keystr])
+        result = self.insertByTime(x, self._context[keystr])
         return result
 
     def newRow(

--- a/src/pyasdm/ReceiverTable.py
+++ b/src/pyasdm/ReceiverTable.py
@@ -459,7 +459,7 @@ class ReceiverTable:
         # make sure there are enough rows in contextRows to hold insertionId
         # probably this just adds one list to contextRows
         while len(contextRows) <= insertionId:
-            contetRows.append([])
+            contextRows.append([])
 
         # and insert this row into the list at insertionId so that list remains ordered in time
         result = self.insertByStartTime(x, contextRows[insertionId])

--- a/src/pyasdm/TotalPowerTable.py
+++ b/src/pyasdm/TotalPowerTable.py
@@ -408,7 +408,7 @@ class TotalPowerTable:
             # Create and initialize an entry in the context dict for this combination....
             self._context[keystr] = []
 
-        result = insertByTime(x, self._context[keystr])
+        result = self.insertByTime(x, self._context[keystr])
         return result
 
     def newRow(


### PR DESCRIPTION
Issue #10 involves using insertByTime instead of self.insertByTime and affects HistoryTable, MainTable, and TotalPowerTable
Issue #11 involves a typo of contetRows instead of contextRows and affects FeedTable and ReceiverTable