### PR TITLE
23 additional problems with SourceTable.py

### DIFF
--- a/src/pyasdm/AlmaRadiometerTable.py
+++ b/src/pyasdm/AlmaRadiometerTable.py
@@ -249,7 +249,7 @@ class AlmaRadiometerTable:
         between parenthesis.
         Example : AlmaRadiometerTable(12)
         """
-        return "AlmaRadiometerTable(" + size() + ")"
+        return "AlmaRadiometerTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/AnnotationTable.py
+++ b/src/pyasdm/AnnotationTable.py
@@ -275,7 +275,7 @@ class AnnotationTable:
         between parenthesis.
         Example : AnnotationTable(12)
         """
-        return "AnnotationTable(" + size() + ")"
+        return "AnnotationTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/AntennaTable.py
+++ b/src/pyasdm/AntennaTable.py
@@ -320,7 +320,7 @@ class AntennaTable:
         between parenthesis.
         Example : AntennaTable(12)
         """
-        return "AntennaTable(" + size() + ")"
+        return "AntennaTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalAmpliTable.py
+++ b/src/pyasdm/CalAmpliTable.py
@@ -297,7 +297,7 @@ class CalAmpliTable:
         between parenthesis.
         Example : CalAmpliTable(12)
         """
-        return "CalAmpliTable(" + size() + ")"
+        return "CalAmpliTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalAntennaSolutionsTable.py
+++ b/src/pyasdm/CalAntennaSolutionsTable.py
@@ -336,7 +336,7 @@ class CalAntennaSolutionsTable:
         between parenthesis.
         Example : CalAntennaSolutionsTable(12)
         """
-        return "CalAntennaSolutionsTable(" + size() + ")"
+        return "CalAntennaSolutionsTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalAppPhaseTable.py
+++ b/src/pyasdm/CalAppPhaseTable.py
@@ -289,7 +289,7 @@ class CalAppPhaseTable:
         between parenthesis.
         Example : CalAppPhaseTable(12)
         """
-        return "CalAppPhaseTable(" + size() + ")"
+        return "CalAppPhaseTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalAtmosphereTable.py
+++ b/src/pyasdm/CalAtmosphereTable.py
@@ -560,7 +560,7 @@ class CalAtmosphereTable:
         between parenthesis.
         Example : CalAtmosphereTable(12)
         """
-        return "CalAtmosphereTable(" + size() + ")"
+        return "CalAtmosphereTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalBandpassTable.py
+++ b/src/pyasdm/CalBandpassTable.py
@@ -384,7 +384,7 @@ class CalBandpassTable:
         between parenthesis.
         Example : CalBandpassTable(12)
         """
-        return "CalBandpassTable(" + size() + ")"
+        return "CalBandpassTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalCurveTable.py
+++ b/src/pyasdm/CalCurveTable.py
@@ -296,7 +296,7 @@ class CalCurveTable:
         between parenthesis.
         Example : CalCurveTable(12)
         """
-        return "CalCurveTable(" + size() + ")"
+        return "CalCurveTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalDataTable.py
+++ b/src/pyasdm/CalDataTable.py
@@ -271,7 +271,7 @@ class CalDataTable:
         between parenthesis.
         Example : CalDataTable(12)
         """
-        return "CalDataTable(" + size() + ")"
+        return "CalDataTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalDelayTable.py
+++ b/src/pyasdm/CalDelayTable.py
@@ -330,7 +330,7 @@ class CalDelayTable:
         between parenthesis.
         Example : CalDelayTable(12)
         """
-        return "CalDelayTable(" + size() + ")"
+        return "CalDelayTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalDeviceTable.py
+++ b/src/pyasdm/CalDeviceTable.py
@@ -395,7 +395,7 @@ class CalDeviceTable:
         between parenthesis.
         Example : CalDeviceTable(12)
         """
-        return "CalDeviceTable(" + size() + ")"
+        return "CalDeviceTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalFluxTable.py
+++ b/src/pyasdm/CalFluxTable.py
@@ -402,7 +402,7 @@ class CalFluxTable:
         between parenthesis.
         Example : CalFluxTable(12)
         """
-        return "CalFluxTable(" + size() + ")"
+        return "CalFluxTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalFocusModelTable.py
+++ b/src/pyasdm/CalFocusModelTable.py
@@ -296,7 +296,7 @@ class CalFocusModelTable:
         between parenthesis.
         Example : CalFocusModelTable(12)
         """
-        return "CalFocusModelTable(" + size() + ")"
+        return "CalFocusModelTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalFocusTable.py
+++ b/src/pyasdm/CalFocusTable.py
@@ -664,7 +664,7 @@ class CalFocusTable:
         between parenthesis.
         Example : CalFocusTable(12)
         """
-        return "CalFocusTable(" + size() + ")"
+        return "CalFocusTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalGainTable.py
+++ b/src/pyasdm/CalGainTable.py
@@ -247,7 +247,7 @@ class CalGainTable:
         between parenthesis.
         Example : CalGainTable(12)
         """
-        return "CalGainTable(" + size() + ")"
+        return "CalGainTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalHolographyTable.py
+++ b/src/pyasdm/CalHolographyTable.py
@@ -475,7 +475,7 @@ class CalHolographyTable:
         between parenthesis.
         Example : CalHolographyTable(12)
         """
-        return "CalHolographyTable(" + size() + ")"
+        return "CalHolographyTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalPhaseTable.py
+++ b/src/pyasdm/CalPhaseTable.py
@@ -350,7 +350,7 @@ class CalPhaseTable:
         between parenthesis.
         Example : CalPhaseTable(12)
         """
-        return "CalPhaseTable(" + size() + ")"
+        return "CalPhaseTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalPointingModelTable.py
+++ b/src/pyasdm/CalPointingModelTable.py
@@ -330,7 +330,7 @@ class CalPointingModelTable:
         between parenthesis.
         Example : CalPointingModelTable(12)
         """
-        return "CalPointingModelTable(" + size() + ")"
+        return "CalPointingModelTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalPointingTable.py
+++ b/src/pyasdm/CalPointingTable.py
@@ -563,7 +563,7 @@ class CalPointingTable:
         between parenthesis.
         Example : CalPointingTable(12)
         """
-        return "CalPointingTable(" + size() + ")"
+        return "CalPointingTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalPositionTable.py
+++ b/src/pyasdm/CalPositionTable.py
@@ -406,7 +406,7 @@ class CalPositionTable:
         between parenthesis.
         Example : CalPositionTable(12)
         """
-        return "CalPositionTable(" + size() + ")"
+        return "CalPositionTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalPrimaryBeamTable.py
+++ b/src/pyasdm/CalPrimaryBeamTable.py
@@ -366,7 +366,7 @@ class CalPrimaryBeamTable:
         between parenthesis.
         Example : CalPrimaryBeamTable(12)
         """
-        return "CalPrimaryBeamTable(" + size() + ")"
+        return "CalPrimaryBeamTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalReductionTable.py
+++ b/src/pyasdm/CalReductionTable.py
@@ -263,7 +263,7 @@ class CalReductionTable:
         between parenthesis.
         Example : CalReductionTable(12)
         """
-        return "CalReductionTable(" + size() + ")"
+        return "CalReductionTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalSeeingTable.py
+++ b/src/pyasdm/CalSeeingTable.py
@@ -392,7 +392,7 @@ class CalSeeingTable:
         between parenthesis.
         Example : CalSeeingTable(12)
         """
-        return "CalSeeingTable(" + size() + ")"
+        return "CalSeeingTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CalWVRTable.py
+++ b/src/pyasdm/CalWVRTable.py
@@ -362,7 +362,7 @@ class CalWVRTable:
         between parenthesis.
         Example : CalWVRTable(12)
         """
-        return "CalWVRTable(" + size() + ")"
+        return "CalWVRTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/ConfigDescriptionTable.py
+++ b/src/pyasdm/ConfigDescriptionTable.py
@@ -283,7 +283,7 @@ class ConfigDescriptionTable:
         between parenthesis.
         Example : ConfigDescriptionTable(12)
         """
-        return "ConfigDescriptionTable(" + size() + ")"
+        return "ConfigDescriptionTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/CorrelatorModeTable.py
+++ b/src/pyasdm/CorrelatorModeTable.py
@@ -267,7 +267,7 @@ class CorrelatorModeTable:
         between parenthesis.
         Example : CorrelatorModeTable(12)
         """
-        return "CorrelatorModeTable(" + size() + ")"
+        return "CorrelatorModeTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/DataDescriptionTable.py
+++ b/src/pyasdm/DataDescriptionTable.py
@@ -253,7 +253,7 @@ class DataDescriptionTable:
         between parenthesis.
         Example : DataDescriptionTable(12)
         """
-        return "DataDescriptionTable(" + size() + ")"
+        return "DataDescriptionTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/DelayModelFixedParametersTable.py
+++ b/src/pyasdm/DelayModelFixedParametersTable.py
@@ -365,7 +365,7 @@ class DelayModelFixedParametersTable:
         between parenthesis.
         Example : DelayModelFixedParametersTable(12)
         """
-        return "DelayModelFixedParametersTable(" + size() + ")"
+        return "DelayModelFixedParametersTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/DelayModelTable.py
+++ b/src/pyasdm/DelayModelTable.py
@@ -475,7 +475,7 @@ class DelayModelTable:
         between parenthesis.
         Example : DelayModelTable(12)
         """
-        return "DelayModelTable(" + size() + ")"
+        return "DelayModelTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/DelayModelVariableParametersTable.py
+++ b/src/pyasdm/DelayModelVariableParametersTable.py
@@ -395,7 +395,7 @@ class DelayModelVariableParametersTable:
         between parenthesis.
         Example : DelayModelVariableParametersTable(12)
         """
-        return "DelayModelVariableParametersTable(" + size() + ")"
+        return "DelayModelVariableParametersTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/DopplerTable.py
+++ b/src/pyasdm/DopplerTable.py
@@ -262,7 +262,7 @@ class DopplerTable:
         between parenthesis.
         Example : DopplerTable(12)
         """
-        return "DopplerTable(" + size() + ")"
+        return "DopplerTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/EphemerisTable.py
+++ b/src/pyasdm/EphemerisTable.py
@@ -370,7 +370,7 @@ class EphemerisTable:
         between parenthesis.
         Example : EphemerisTable(12)
         """
-        return "EphemerisTable(" + size() + ")"
+        return "EphemerisTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/ExecBlockTable.py
+++ b/src/pyasdm/ExecBlockTable.py
@@ -455,7 +455,7 @@ class ExecBlockTable:
         between parenthesis.
         Example : ExecBlockTable(12)
         """
-        return "ExecBlockTable(" + size() + ")"
+        return "ExecBlockTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/FeedTable.py
+++ b/src/pyasdm/FeedTable.py
@@ -485,7 +485,7 @@ class FeedTable:
         between parenthesis.
         Example : FeedTable(12)
         """
-        return "FeedTable(" + size() + ")"
+        return "FeedTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/FieldTable.py
+++ b/src/pyasdm/FieldTable.py
@@ -328,7 +328,7 @@ class FieldTable:
         between parenthesis.
         Example : FieldTable(12)
         """
-        return "FieldTable(" + size() + ")"
+        return "FieldTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/FlagCmdTable.py
+++ b/src/pyasdm/FlagCmdTable.py
@@ -339,7 +339,7 @@ class FlagCmdTable:
         between parenthesis.
         Example : FlagCmdTable(12)
         """
-        return "FlagCmdTable(" + size() + ")"
+        return "FlagCmdTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/FlagTable.py
+++ b/src/pyasdm/FlagTable.py
@@ -271,7 +271,7 @@ class FlagTable:
         between parenthesis.
         Example : FlagTable(12)
         """
-        return "FlagTable(" + size() + ")"
+        return "FlagTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/FocusModelTable.py
+++ b/src/pyasdm/FocusModelTable.py
@@ -274,7 +274,7 @@ class FocusModelTable:
         between parenthesis.
         Example : FocusModelTable(12)
         """
-        return "FocusModelTable(" + size() + ")"
+        return "FocusModelTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/FocusTable.py
+++ b/src/pyasdm/FocusTable.py
@@ -434,7 +434,7 @@ class FocusTable:
         between parenthesis.
         Example : FocusTable(12)
         """
-        return "FocusTable(" + size() + ")"
+        return "FocusTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/FreqOffsetTable.py
+++ b/src/pyasdm/FreqOffsetTable.py
@@ -381,7 +381,7 @@ class FreqOffsetTable:
         between parenthesis.
         Example : FreqOffsetTable(12)
         """
-        return "FreqOffsetTable(" + size() + ")"
+        return "FreqOffsetTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/GainTrackingTable.py
+++ b/src/pyasdm/GainTrackingTable.py
@@ -380,7 +380,7 @@ class GainTrackingTable:
         between parenthesis.
         Example : GainTrackingTable(12)
         """
-        return "GainTrackingTable(" + size() + ")"
+        return "GainTrackingTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/HistoryTable.py
+++ b/src/pyasdm/HistoryTable.py
@@ -324,7 +324,7 @@ class HistoryTable:
         between parenthesis.
         Example : HistoryTable(12)
         """
-        return "HistoryTable(" + size() + ")"
+        return "HistoryTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/HolographyTable.py
+++ b/src/pyasdm/HolographyTable.py
@@ -289,7 +289,7 @@ class HolographyTable:
         between parenthesis.
         Example : HolographyTable(12)
         """
-        return "HolographyTable(" + size() + ")"
+        return "HolographyTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/MainTable.py
+++ b/src/pyasdm/MainTable.py
@@ -337,7 +337,7 @@ class MainTable:
         between parenthesis.
         Example : MainTable(12)
         """
-        return "MainTable(" + size() + ")"
+        return "MainTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/ModulationTable.py
+++ b/src/pyasdm/ModulationTable.py
@@ -391,7 +391,7 @@ class ModulationTable:
         between parenthesis.
         Example : ModulationTable(12)
         """
-        return "ModulationTable(" + size() + ")"
+        return "ModulationTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/ObservationTable.py
+++ b/src/pyasdm/ObservationTable.py
@@ -241,7 +241,7 @@ class ObservationTable:
         between parenthesis.
         Example : ObservationTable(12)
         """
-        return "ObservationTable(" + size() + ")"
+        return "ObservationTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/PointingModelTable.py
+++ b/src/pyasdm/PointingModelTable.py
@@ -278,7 +278,7 @@ class PointingModelTable:
         between parenthesis.
         Example : PointingModelTable(12)
         """
-        return "PointingModelTable(" + size() + ")"
+        return "PointingModelTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/PointingTable.py
+++ b/src/pyasdm/PointingTable.py
@@ -518,7 +518,7 @@ class PointingTable:
         between parenthesis.
         Example : PointingTable(12)
         """
-        return "PointingTable(" + size() + ")"
+        return "PointingTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/PolarizationTable.py
+++ b/src/pyasdm/PolarizationTable.py
@@ -249,7 +249,7 @@ class PolarizationTable:
         between parenthesis.
         Example : PolarizationTable(12)
         """
-        return "PolarizationTable(" + size() + ")"
+        return "PolarizationTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/PostProcessingTable.py
+++ b/src/pyasdm/PostProcessingTable.py
@@ -263,7 +263,7 @@ class PostProcessingTable:
         between parenthesis.
         Example : PostProcessingTable(12)
         """
-        return "PostProcessingTable(" + size() + ")"
+        return "PostProcessingTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/ProcessorTable.py
+++ b/src/pyasdm/ProcessorTable.py
@@ -249,7 +249,7 @@ class ProcessorTable:
         between parenthesis.
         Example : ProcessorTable(12)
         """
-        return "ProcessorTable(" + size() + ")"
+        return "ProcessorTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/PulsarTable.py
+++ b/src/pyasdm/PulsarTable.py
@@ -305,7 +305,7 @@ class PulsarTable:
         between parenthesis.
         Example : PulsarTable(12)
         """
-        return "PulsarTable(" + size() + ")"
+        return "PulsarTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/ReceiverTable.py
+++ b/src/pyasdm/ReceiverTable.py
@@ -387,7 +387,7 @@ class ReceiverTable:
         between parenthesis.
         Example : ReceiverTable(12)
         """
-        return "ReceiverTable(" + size() + ")"
+        return "ReceiverTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/SBSummaryTable.py
+++ b/src/pyasdm/SBSummaryTable.py
@@ -298,7 +298,7 @@ class SBSummaryTable:
         between parenthesis.
         Example : SBSummaryTable(12)
         """
-        return "SBSummaryTable(" + size() + ")"
+        return "SBSummaryTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/ScaleTable.py
+++ b/src/pyasdm/ScaleTable.py
@@ -251,7 +251,7 @@ class ScaleTable:
         between parenthesis.
         Example : ScaleTable(12)
         """
-        return "ScaleTable(" + size() + ")"
+        return "ScaleTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/ScanTable.py
+++ b/src/pyasdm/ScanTable.py
@@ -257,7 +257,7 @@ class ScanTable:
         between parenthesis.
         Example : ScanTable(12)
         """
-        return "ScanTable(" + size() + ")"
+        return "ScanTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/SeeingTable.py
+++ b/src/pyasdm/SeeingTable.py
@@ -375,7 +375,7 @@ class SeeingTable:
         between parenthesis.
         Example : SeeingTable(12)
         """
-        return "SeeingTable(" + size() + ")"
+        return "SeeingTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/SourceTable.py
+++ b/src/pyasdm/SourceTable.py
@@ -748,7 +748,7 @@ class SourceTable:
         between parenthesis.
         Example : SourceTable(12)
         """
-        return "SourceTable(" + size() + ")"
+        return "SourceTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 
@@ -779,7 +779,7 @@ class SourceTable:
 
         # print("Trying to add a new row with start time = "+str(startTime))
 
-        insertionId = self._name2id_dict.get[x.getSourceName()]
+        insertionId = self._name2id_dict[x.getSourceName()]
 
         # sourceId is now known from the dictionary
         # context is a vector of vectors, sourceId index to the outer vector and

--- a/src/pyasdm/SpectralWindowTable.py
+++ b/src/pyasdm/SpectralWindowTable.py
@@ -534,7 +534,7 @@ class SpectralWindowTable:
         between parenthesis.
         Example : SpectralWindowTable(12)
         """
-        return "SpectralWindowTable(" + size() + ")"
+        return "SpectralWindowTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/SquareLawDetectorTable.py
+++ b/src/pyasdm/SquareLawDetectorTable.py
@@ -251,7 +251,7 @@ class SquareLawDetectorTable:
         between parenthesis.
         Example : SquareLawDetectorTable(12)
         """
-        return "SquareLawDetectorTable(" + size() + ")"
+        return "SquareLawDetectorTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/StateTable.py
+++ b/src/pyasdm/StateTable.py
@@ -255,7 +255,7 @@ class StateTable:
         between parenthesis.
         Example : StateTable(12)
         """
-        return "StateTable(" + size() + ")"
+        return "StateTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/StationTable.py
+++ b/src/pyasdm/StationTable.py
@@ -272,7 +272,7 @@ class StationTable:
         between parenthesis.
         Example : StationTable(12)
         """
-        return "StationTable(" + size() + ")"
+        return "StationTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/SubscanTable.py
+++ b/src/pyasdm/SubscanTable.py
@@ -253,7 +253,7 @@ class SubscanTable:
         between parenthesis.
         Example : SubscanTable(12)
         """
-        return "SubscanTable(" + size() + ")"
+        return "SubscanTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/SwitchCycleTable.py
+++ b/src/pyasdm/SwitchCycleTable.py
@@ -297,7 +297,7 @@ class SwitchCycleTable:
         between parenthesis.
         Example : SwitchCycleTable(12)
         """
-        return "SwitchCycleTable(" + size() + ")"
+        return "SwitchCycleTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/SysCalTable.py
+++ b/src/pyasdm/SysCalTable.py
@@ -466,7 +466,7 @@ class SysCalTable:
         between parenthesis.
         Example : SysCalTable(12)
         """
-        return "SysCalTable(" + size() + ")"
+        return "SysCalTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/SysPowerTable.py
+++ b/src/pyasdm/SysPowerTable.py
@@ -427,7 +427,7 @@ class SysPowerTable:
         between parenthesis.
         Example : SysPowerTable(12)
         """
-        return "SysPowerTable(" + size() + ")"
+        return "SysPowerTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/TotalPowerTable.py
+++ b/src/pyasdm/TotalPowerTable.py
@@ -367,7 +367,7 @@ class TotalPowerTable:
         between parenthesis.
         Example : TotalPowerTable(12)
         """
-        return "TotalPowerTable(" + size() + ")"
+        return "TotalPowerTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/VLAWVRTable.py
+++ b/src/pyasdm/VLAWVRTable.py
@@ -396,7 +396,7 @@ class VLAWVRTable:
         between parenthesis.
         Example : VLAWVRTable(12)
         """
-        return "VLAWVRTable(" + size() + ")"
+        return "VLAWVRTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/WVMCalTable.py
+++ b/src/pyasdm/WVMCalTable.py
@@ -404,7 +404,7 @@ class WVMCalTable:
         between parenthesis.
         Example : WVMCalTable(12)
         """
-        return "WVMCalTable(" + size() + ")"
+        return "WVMCalTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/src/pyasdm/WeatherTable.py
+++ b/src/pyasdm/WeatherTable.py
@@ -581,7 +581,7 @@ class WeatherTable:
         between parenthesis.
         Example : WeatherTable(12)
         """
-        return "WeatherTable(" + size() + ")"
+        return "WeatherTable(" + str(self.size()) + ")"
 
     # ====> Row creation.
 

--- a/tests/test_SourceTable.py
+++ b/tests/test_SourceTable.py
@@ -1,0 +1,47 @@
+
+import unittest
+import pyasdm
+
+class source_table_test(unittest.TestCase):
+
+    def setUp(self):
+        # nothing to do here
+        pass
+
+    def tearDown(self):
+        # nothing to do here
+        pass
+
+    def test_table_row(self):
+        # a simple test to add a row to an empty SourceTable directly from XML
+        # nothing is written to disk
+        
+        test_asdm = pyasdm.ASDM()
+        source_row_0_xml = """
+        <row>
+        <sourceId> 0 </sourceId>
+        <timeInterval> 7090683272335387903 4265377529038775807 </timeInterval>
+        <code> none </code>
+        <direction> 1 2 1.3528024488371877 0.31436086058385826  </direction>
+        <properMotion> 1 2 0.0 0.0  </properMotion>
+        <sourceName> J0510+1800 </sourceName>
+        <directionCode>ICRS</directionCode>
+        <numFreq> 4 </numFreq>
+        <numStokes> 4 </numStokes>
+        <frequency> 1 4 2.1998305541101968E11 2.1800401136221878E11 2.3300428785048865E11 2.350043230298097E11  </frequency>
+        <stokesParameter> 1 4 I Q U V</stokesParameter>
+        <flux> 2 4 4 3.855274498565509 0.0 0.0 0.0 3.8656094704537534 0.0 0.0 0.0 3.7901533014049034 0.0 0.0 0.0 3.7805688135422617 0.0 0.0 0.0  </flux>
+        <size> 2 4 2 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0  </size>
+        <spectralWindowId> SpectralWindow_0 </spectralWindowId>
+        </row>
+        """
+
+        source_table = test_asdm.getSource()
+        source_row_0 = pyasdm.SourceRow(source_table)
+        source_row_0.setFromXML(source_row_0_xml)
+        source_table.add(source_row_0)
+        print(source_table)
+
+if __name__ == "__main__":
+
+    unittest.main()


### PR DESCRIPTION
Fixed bug in use of internal dict, _name2id_dict, which incorrectly mixed the get method and the [] method for getting an item. It just uses the [] method.

Fixed a bug in _str_ for all tables which was noticed first in SourceTable. 

Added test_SourceTable.py which needs more work but does verify that these changes work as expected.